### PR TITLE
Add Boku no Natsuyasumi 2 (PS2) English translation

### DIFF
--- a/DATs/021 - Lost Level Archive - Sony - PlayStation 2 (v2024-07-04).dat
+++ b/DATs/021 - Lost Level Archive - Sony - PlayStation 2 (v2024-07-04).dat
@@ -10,6 +10,11 @@
 		<url>https://www.github.com/televandalist/lost-level-archive</url>
 		<clrmamepro forcenodump="required"/>
 	</header>
+	<game name="Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan) (En) (v1.2) (Hilltop)" cloneof="Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan)">
+		<description>Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan) (En) (v1.2) (Hilltop)</description>
+		<release name="Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan) (En) (v1.2) (Hilltop)" type="Translation" region="Japan"/>
+		<rom name="Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan) (En) (v1.2) (Hilltop).iso" size="3576135680" crc="3953BE9B" md5="C233E45F26E2E7DD10F40CED77DD9EFF" sha1="DDDFF595592443F0BFAD9C1118251A5393136CD7"/>
+	</game>
 	<game name="Half-Life - Blue Shift - Anniversary Edition (v1.20) (supadupaplex)" cloneof="Half-Life (USA)">
 		<description>Half-Life - Blue Shift - Anniversary Edition (v1.20) (supadupaplex)</description>
 		<release name="Half-Life - Blue Shift - Anniversary Edition (v1.20) (supadupaplex)" type="Hack" region="USA"/>


### PR DESCRIPTION
This is v1.2 of Hilltop's English translation, found here: https://www.patreon.com/posts/92070798
The patch is 1.3 GB, too large for RAPatches.

It is applied to Redump: [Boku no Natsuyasumi 2 - Umi no Bouken-hen (Japan)](http://redump.org/disc/38271/)

Hash management page: https://retroachievements.org/game/20646/hashes/manage