### PR TITLE
Add GameCube datfile

### DIFF
--- a/DATs/016 - Lost Level Archive - Nintendo - GameCube (v2024-11-24).xml
+++ b/DATs/016 - Lost Level Archive - Nintendo - GameCube (v2024-11-24).xml
@@ -19,6 +19,14 @@
 		<description>Movie Mashup (v1.0) (Eyepie)</description>
 		<rom name="Movie Mashup (v1.0) (Eyepie).iso" size="581435392" crc="007bccbd" md5="0c055649336ee34ac47e4a54e709d1cf" sha1="cfcb59ed719bc83651d4adbfffa5bab7e8501eb2" />
 	</game>
+	<game name="Sonic Riders - Tournament Edition (v2.4) (SRTE Dev Team)" cloneof="Sonic Riders (USA) (En,Ja,Fr,De,Es,It)">
+		<description>Sonic Riders - Tournament Edition (v2.4) (SRTE Dev Team)</description>
+		<rom name="Sonic Riders - Tournament Edition (v2.4) (SRTE Dev Team).iso" size="2104557568" crc="861ae034" md5="9cbc195582c9cecf9b496db34347577a" sha1="788468169873927f28a3072044e3985c7bca4bf6" />
+	</game>
+	<game name="Sonic Riders DX (v2.1) (Extreme Gear Labs)" cloneof="Sonic Riders (USA) (En,Ja,Fr,De,Es,It)">
+		<description>Sonic Riders DX (v2.1) (Extreme Gear Labs)</description>
+		<rom name="Sonic Riders DX (v2.1) (Extreme Gear Labs).iso" size="1378942976" crc="64a25d95" md5="31a47dce756825f19e6e1d48f32ef48e" sha1="34af4d88b357abafcf16707ac9f00947a5586f95" />
+	</game>
 	<game name="SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL)" cloneof="Nickelodeon SpongeBob SquarePants - Battle for Bikini Bottom (USA)">
 		<description>SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL)</description>
 		<rom name="SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL).iso" size="1090191360" crc="863ac998" md5="b7ae3e9ca6635ae5dd23cf62d2227972" sha1="f9f879e7f0765e7d7ad698b45d654a39351a726f" />
@@ -30,5 +38,9 @@
 	<game name="SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator)" cloneof="Nickelodeon SpongeBob SquarePants - The Movie (USA) (Rev 1)">
 		<description>SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator)</description>
 		<rom name="SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator).iso" size="1222246400" crc="7d7917d6" md5="7b593d713dfedc4bdada456bc5e2d923" sha1="b80ffd58d38e030d18d377de546d937e66ea9391" />
+	</game>
+	<game name="Super Doot Sunshine (v1.4.0) (warspyking)" cloneof="Super Mario Sunshine (USA)">
+		<description>Super Doot Sunshine (v1.4.0) (warspyking)</description>
+		<rom name="Super Doot Sunshine (v1.4.0) (warspyking).iso" size="1459978240" crc="1e0e558e" md5="ee334e837718b5acb41ce5145a532165" sha1="90ffb58ecd98d137861414a5a52217ee8b40f08b" />
 	</game>
 </datafile>

--- a/DATs/016 - Lost Level Archive - Nintendo - GameCube (v2024-11-24).xml
+++ b/DATs/016 - Lost Level Archive - Nintendo - GameCube (v2024-11-24).xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+<datafile>
+	<header>
+		<id>016</id>
+		<name>016 - Lost Level Archive - Nintendo - GameCube</name>
+		<description>Nintendo - GameCube</description>
+		<version>v20241124</version>
+		<author>televandalist</author>
+		<homepage>Lost Level Archive</homepage>
+		<url>https://www.github.com/televandalist/lost-level-archive</url>
+		<clrmamepro forcenodump="required"/>
+	</header>
+	<game name="BFBBMix (v5.06) (skyweiss)" cloneof="Nickelodeon SpongeBob SquarePants - Battle for Bikini Bottom (USA)">
+		<description>BFBBMix (v5.06) (skyweiss)</description>
+		<rom name="BFBBMix (v5.06) (skyweiss).iso" size="834306048" crc="252ce672" md5="a7d63448fde422621909b042864f6a27" sha1="24884bb8e6533b85857c1cae328760c6142bc362" />
+	</game>
+	<game name="Movie Mashup (v1.0) (Eyepie)" cloneof="Nickelodeon SpongeBob SquarePants - The Movie (USA) (Rev 1)">
+		<description>Movie Mashup (v1.0) (Eyepie)</description>
+		<rom name="Movie Mashup (v1.0) (Eyepie).iso" size="581435392" crc="007bccbd" md5="0c055649336ee34ac47e4a54e709d1cf" sha1="cfcb59ed719bc83651d4adbfffa5bab7e8501eb2" />
+	</game>
+	<game name="SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL)" cloneof="Nickelodeon SpongeBob SquarePants - Battle for Bikini Bottom (USA)">
+		<description>SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL)</description>
+		<rom name="SpongeBob SquarePants - Battle for Bikini Bottom - Beta Mod (v2.2) (TLL).iso" size="1090191360" crc="863ac998" md5="b7ae3e9ca6635ae5dd23cf62d2227972" sha1="f9f879e7f0765e7d7ad698b45d654a39351a726f" />
+	</game>
+	<game name="SpongeBob SquarePants - Battle for Bikini Bottom - Second Strike (v1.02.1) (Aaron5015)" cloneof="Nickelodeon SpongeBob SquarePants - Battle for Bikini Bottom (USA)">
+		<description>SpongeBob SquarePants - Battle for Bikini Bottom - Second Strike (v1.02.1) (Aaron5015)</description>
+		<rom name="SpongeBob SquarePants - Battle for Bikini Bottom - Second Strike (v1.02.1) (Aaron5015).iso" size="1617723392" crc="42e5a63c" md5="7ccfef4914d6beb46289d12da4bb0d4f" sha1="b91fe52758ec2a254d12a0c5eafda681c47405b1" />
+	</game>
+	<game name="SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator)" cloneof="Nickelodeon SpongeBob SquarePants - The Movie (USA) (Rev 1)">
+		<description>SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator)</description>
+		<rom name="SpongeBob SquarePants - The Movie - Encore (v1.2) (Koopa Eliminator).iso" size="1222246400" crc="7d7917d6" md5="7b593d713dfedc4bdada456bc5e2d923" sha1="b80ffd58d38e030d18d377de546d937e66ea9391" />
+	</game>
+</datafile>


### PR DESCRIPTION
Added a GC datfile (copied from the template of the updated Genesis datfile), starting with some SpongeBob hacks.

These hacks are built by extracting the disc in Dolphin, replacing with the mod files, then converting it back into an ISO, as explained in this video: https://www.youtube.com/watch?v=NXu3dwnA0zc
An xdelta patch can be created after, but these may or may not be too big for RAPatches.

**BFBBMix**
https://gamebanana.com/mods/53847
http://redump.org/disc/8792/
https://retroachievements.org/manage/games/31937
xdelta patch is 538 MB

**Movie Mashup**
https://gamebanana.com/mods/498828
http://redump.org/disc/6318/
https://retroachievements.org/manage/games/31936
xdelta patch is 140 MB

**SpongeBob SquarePants: Battle for Bikini Bottom - Beta Mod**
https://gamebanana.com/mods/388746
http://redump.org/disc/8792/
https://retroachievements.org/manage/games/31938
xdelta patch is 724 MB

**SpongeBob SquarePants: Battle for Bikini Bottom - Second Strike**
https://gamebanana.com/mods/53848
http://redump.org/disc/8792/
https://retroachievements.org/manage/games/31965
xdelta patch is 644 MB

**SpongeBob SquarePants: The Movie - Encore**
https://www.heavyironmodding.org/wiki/Movie_Encore
http://redump.org/disc/6318/
https://retroachievements.org/manage/games/31966
xdelta patch is 1 GB